### PR TITLE
Make Geoserver publish optional and add optional run_all target

### DIFF
--- a/scripts/publish_geoserver.py
+++ b/scripts/publish_geoserver.py
@@ -11,12 +11,20 @@ def create_coverage_store(yaml_file, output_file):
     with open(yaml_file, 'r') as f:
         config = yaml.safe_load(f)
 
-    geoserver_url = config.get("geoserver")['url']
-    workspace = config.get("geoserver")['workspace']
+    geoserver = config.get("geoserver", {})
+    publish_geoserver = geoserver.get("publish_geoserver", False)
+    if not publish_geoserver:
+        with open(str(output_file), 'w', encoding='utf-8') as f:
+            f.write("")
+        print("Publicación en Geoserver desactivada; se omite la creación del coverage store.")
+        return
+
+    geoserver_url = geoserver['url']
+    workspace = geoserver['workspace']
     coveragestore = config.get("title")
-    style = config.get("geoserver")["style"]
-    username = config.get("geoserver")['username']
-    password = config.get("geoserver")['password']
+    style = geoserver["style"]
+    username = geoserver['username']
+    password = geoserver['password']
     tif_path = config.get("file")
 
     status_code = 0
@@ -302,4 +310,3 @@ if __name__ == "__main__":
             xml_file_path = sys.argv[2]
             output_file = sys.argv[3]
     create_coverage_store(yaml_file, output_file)
-

--- a/scripts/update_metadata.py
+++ b/scripts/update_metadata.py
@@ -35,8 +35,10 @@ def update_metadata(xml_file, record_id, combined_response, output_file, wms_url
     tree = ET.parse(xml_file)
     root = tree.getroot()
 
+    wms_url = wms_url.strip()
+
     # Inserción del bloque onLine dentro de transferOptions en MD_Distribution
-    if wms_url != "":
+    if wms_url:
         # Buscar el elemento <gmd:distributionInfo/gmd:MD_Distribution>
         md_distribution = root.find(".//gmd:distributionInfo/gmd:MD_Distribution", namespaces)
         if md_distribution is None:
@@ -67,7 +69,7 @@ def update_metadata(xml_file, record_id, combined_response, output_file, wms_url
         # Elemento <gmd:name>
         name_elem = ET.SubElement(ci_online_resource, f"{{{namespaces['gmd']}}}name")
         char_name = ET.SubElement(name_elem, f"{{{namespaces['gco']}}}CharacterString")
-        char_name.text = config.get("title")
+        char_name.text = config.get("title") or config.get("file", "")
 
         # Elemento <gmd:function>
         name_elem = ET.SubElement(ci_online_resource, f"{{{namespaces['gmd']}}}function")

--- a/snakefile
+++ b/snakefile
@@ -134,3 +134,13 @@ rule update_metadata:
 rule all:
     input:
         "temp_files/final_metadata.xml",
+
+# Regla opcional para ejecutar todos los pasos (incluye validación) con reanudación automática
+rule run_all:
+    input:
+        rules.validation.output,
+        rules.update_metadata.output
+    output:
+        "logs/run_all.done"
+    shell:
+        "touch {output}"


### PR DESCRIPTION
### Motivation
- Keep the default `all` target unchanged while providing an explicit optional `run_all` target to run validation + full pipeline with resume semantics. 
- Allow disabling Geoserver publication from the YAML so the pipeline can run in environments without Geoserver credentials. 
- Ensure the metadata updater treats WMS URLs robustly and falls back to a sensible name when a title is not available.

### Description
- Kept `rule all` targeting `temp_files/final_metadata.xml` and added an explicit optional `rule run_all` that depends on `rules.validation.output` and `rules.update_metadata.output` and produces `logs/run_all.done` in `snakefile`.
- Updated `scripts/publish_geoserver.py` to read `geoserver.publish_geoserver` from the config and skip creating/uploading the coverage store when disabled, writing an empty output file and returning early instead of failing.
- Refactored `scripts/publish_geoserver.py` to use the `geoserver` sub-dictionary for credentials and settings (e.g. `geoserver['url']`, `geoserver['workspace']`).
- Hardened `scripts/update_metadata.py` by trimming the WMS URL (`wms_url.strip()`), making the OGC `onLine` block conditional only when a non-empty URL exists, and falling back to the dataset filename when `metadata.title` is absent for the `gmd:name` element.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69847f6fbad88330809e900937fd8adf)