### PR TITLE
Normalize metadata parameters and improve upload config parsing

### DIFF
--- a/scripts/add_contentinfo.py
+++ b/scripts/add_contentinfo.py
@@ -41,12 +41,27 @@ def insert_after(target_elem, new_elem, parent):
     parent.append(new_elem)
 
 
+def normalize_parameters(parameters_cfg):
+    if isinstance(parameters_cfg, dict):
+        return parameters_cfg
+    if isinstance(parameters_cfg, list):
+        normalized = {}
+        for idx, item in enumerate(parameters_cfg):
+            if not isinstance(item, dict):
+                continue
+            key = item.get("key") or item.get("name") or f"param_{idx + 1}"
+            normalized[key] = item
+        return normalized
+    return {}
+
+
 def update_contentinfo(root, parameters_cfg):
     """
     Inserta un bloque <gmd:contentInfo> -> <gmi:MI_CoverageDescription> con
     rangeElementDescription para cada parámetro (name, definition, unit).
     Sin error/precision (para no invalidar la ISO en gmi:MI_Band).
     """
+    parameters_cfg = normalize_parameters(parameters_cfg)
     if not parameters_cfg:
         return None  # No hay contentInfo si no hay parámetros
 
@@ -208,10 +223,9 @@ def add_data_quality(root, config):
     - Se ubica cada dataQualityInfo tras <gmd:identificationInfo>, si existe, o se appendea al root.
     """
 
-    parameters = config.get("metadata").get("parameters", {})
+    parameters = normalize_parameters(config.get("metadata").get("parameters", {}))
     if not parameters:
         print("No se encontró 'parameters' en YAML. No se añaden dataQualityInfo.")
-        tree.write(output_file, encoding="utf-8", xml_declaration=True)
         return
 
     # Ubicación donde insertamos dataQuality


### PR DESCRIPTION
### Motivation
- Fix a crash in `add_contentinfo.py` where `metadata.parameters` was a list and code expected a dict, causing `AttributeError: 'list' object has no attribute 'items'`.
- Prevent `upload_data.py` from failing with `TypeError: 'NoneType' object is not subscriptable` due to inconsistent config lookups for GeoNetwork and storage entries.
- Correct manual CLI argument parsing for `upload_data.py` which used the wrong `sys.argv` index for the output path.

### Description
- Added `normalize_parameters()` to `scripts/add_contentinfo.py` to accept either a list or dict for `metadata.parameters` and used it in `update_contentinfo()` and `add_data_quality()` so code can iterate safely and produce `gmd:contentInfo`/`gmd:dataQualityInfo` blocks.
- Removed an invalid early write in the no-parameters path and retained the pretty-printing save flow to avoid writing incomplete XML.
- Added `_get_nested()` helper to `scripts/upload_data.py`, made `upload_data()` read `services.geonetwork` (with fallback to top-level `geonetwork`) and `dataset.file` (with fallback), added explicit validation of required storage and geonetwork fields, and fixed the manual CLI `output_file` index from `sys.argv[4]` to `sys.argv[5]`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69848ad65084833086e82fcbf564f7f5)