### PR TITLE
Añadir paso de validación de metadatos en Geonetwork al flujo Snakemake

### DIFF
--- a/scripts/upload_data/upload_data.py
+++ b/scripts/upload_data/upload_data.py
@@ -8,7 +8,7 @@ from botocore.client import Config as BotoConfig
 from boto3.s3.transfer import TransferConfig, S3Transfer
 import yaml
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 def _get_nested(config, *keys):
     current = config
@@ -96,7 +96,8 @@ def upload_data(session_file, record_id_file, config, png_file_path, output_file
             sys.stdout.flush()
 
     # === SUBIDA A S3 ===
-    ts = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    ts_dt = datetime.now(timezone.utc) 
+    ts = ts_dt.isoformat()
     transfer = S3Transfer(client=s3, config=tfr_cfg)
     transfer.upload_file(
         local_file,

--- a/scripts/validation/validate_metadata_geonetwork.py
+++ b/scripts/validation/validate_metadata_geonetwork.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+import requests
+import yaml
+
+
+def load_session(session_file):
+    with open(session_file, 'r', encoding='utf-8') as f:
+        session_info = json.load(f)
+    xsrf_token = session_info.get("XSRF-TOKEN")
+    cookies = session_info.get("cookies", {})
+    if not xsrf_token:
+        raise ValueError("No se encontró el token XSRF en el archivo de sesión.")
+    return xsrf_token, cookies
+
+
+def read_record_id(record_id_file):
+    with open(record_id_file, 'r', encoding='utf-8') as f:
+        record_id = f.read().strip()
+    if not record_id:
+        raise ValueError("El archivo de record_id está vacío.")
+    return record_id
+
+
+def load_geonetwork_url(config_file):
+    with open(config_file, 'r', encoding='utf-8') as f:
+        config = yaml.safe_load(f)
+    geonetwork_url = config.get("services", {}).get("geonetwork", {}).get("url")
+    if not geonetwork_url:
+        raise ValueError("No se encontró services.geonetwork.url en el config.")
+    return geonetwork_url.rstrip('/')
+
+
+def validate_metadata(config_file, session_file, record_id_file, output_file):
+    geonetwork_url = load_geonetwork_url(config_file)
+    xsrf_token, cookies = load_session(session_file)
+    record_id = read_record_id(record_id_file)
+
+    session = requests.Session()
+    session.cookies.update(cookies)
+    headers = {
+        'Accept': 'application/json',
+        'X-XSRF-TOKEN': xsrf_token,
+    }
+
+    validate_url = f"{geonetwork_url}/srv/api/records/{record_id}/validate"
+    response = session.post(validate_url, headers=headers)
+
+    if response.status_code not in [200, 201]:
+        print(f"Error al validar metadatos: {response.status_code} - {response.text}")
+        sys.exit(1)
+
+    output_path = Path(output_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {"raw_response": response.text}
+
+    output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding='utf-8')
+    print(f"Validación completada. Resultado guardado en: {output_file}")
+
+
+if __name__ == "__main__":
+    try:
+        config_file = snakemake.input.config
+        session_file = snakemake.input.session
+        record_id_file = snakemake.input.record_id
+        output_file = snakemake.output[0]
+    except NameError:
+        if len(sys.argv) < 5:
+            print("Uso: validate_metadata_geonetwork.py <config_file> <session_file> <record_id_file> <output_file>")
+            sys.exit(1)
+        config_file = sys.argv[1]
+        session_file = sys.argv[2]
+        record_id_file = sys.argv[3]
+        output_file = sys.argv[4]
+
+    validate_metadata(config_file, session_file, record_id_file, output_file)

--- a/scripts/validation/validate_metadata_geonetwork.py
+++ b/scripts/validation/validate_metadata_geonetwork.py
@@ -34,23 +34,50 @@ def load_geonetwork_url(config_file):
     return geonetwork_url.rstrip('/')
 
 
-def validate_metadata(config_file, session_file, record_id_file, output_file):
+def validate_metadata(config_file, session_file, record_id_file, combined_response_file, output_file):
+    with open(combined_response_file, 'r', encoding='utf-8') as f:
+        combined_response = json.load(f)
+
+    
     geonetwork_url = load_geonetwork_url(config_file)
     xsrf_token, cookies = load_session(session_file)
-    record_id = read_record_id(record_id_file)
+    record_id = combined_response['png_response']['metadataId']
 
     session = requests.Session()
     session.cookies.update(cookies)
+    headers = {
+        'X-XSRF-TOKEN': xsrf_token,
+    }
+
+    edit_url = f"{geonetwork_url}/srv/api/records/{record_id}/editor"
+    print(edit_url)
+    response = session.get(edit_url, headers=headers)
+
+    if response.status_code not in [200, 201]:
+        print(f"Error al edit metadatos: {response.status_code} - {response.text}")
+        sys.exit(1)
+
     headers = {
         'Accept': 'application/json',
         'X-XSRF-TOKEN': xsrf_token,
     }
 
-    validate_url = f"{geonetwork_url}/srv/api/records/{record_id}/validate"
-    response = session.post(validate_url, headers=headers)
+    validate_url = f"{geonetwork_url}/srv/api/records/{record_id}/validate/internal"
+    print(validate_url)
+    response = session.put(validate_url, headers=headers)
 
-    if response.status_code not in [200, 201]:
+    if response.status_code not in [200, 201, 204]:
         print(f"Error al validar metadatos: {response.status_code} - {response.text}")
+        sys.exit(1)
+
+    headers = {
+        'X-XSRF-TOKEN': xsrf_token,
+    }
+
+    response = session.delete(edit_url, headers=headers)
+
+    if response.status_code not in [200, 201, 204]:
+        print(f"Error al edit metadatos: {response.status_code} - {response.text}")
         sys.exit(1)
 
     output_path = Path(output_file)
@@ -70,14 +97,16 @@ if __name__ == "__main__":
         config_file = snakemake.input.config
         session_file = snakemake.input.session
         record_id_file = snakemake.input.record_id
+        combined_response_file = snakemake.input.upload_response  # Ej.: "upload_response.json"
         output_file = snakemake.output[0]
     except NameError:
-        if len(sys.argv) < 5:
-            print("Uso: validate_metadata_geonetwork.py <config_file> <session_file> <record_id_file> <output_file>")
+        if len(sys.argv) < 6:
+            print("Uso: validate_metadata_geonetwork.py <config_file> <session_file> <record_id_file> <combined_response_file> <output_file>")
             sys.exit(1)
         config_file = sys.argv[1]
         session_file = sys.argv[2]
         record_id_file = sys.argv[3]
-        output_file = sys.argv[4]
+        combined_response_file = sys.argv[4]
+        output_file = sys.argv[5]
 
-    validate_metadata(config_file, session_file, record_id_file, output_file)
+    validate_metadata(config_file, session_file, record_id_file, combined_response_file, output_file)

--- a/snakefile
+++ b/snakefile
@@ -152,13 +152,24 @@ rule update_metadata:
     script:
         "scripts/final_update/update_metadata.py"
 
+rule validate_metadata_geonetwork:
+    input:
+        config="config.yaml",
+        session="temp_files/geonetwork_session.txt",
+        record_id="temp_files/metadata_uploaded.txt",
+        metadata=rules.update_metadata.output
+    output:
+        "logs/metadata_validation.json"
+    script:
+        "scripts/validation/validate_metadata_geonetwork.py"
+
 
 
 # Regla para ejecutar todos los pasos y permitir reanudación desde el último correcto
 rule run_all:
     input:
         rules.validation.output,
-        rules.update_metadata.output
+        rules.validate_metadata_geonetwork.output
     output:
         "logs/run_all.done"
     shell:
@@ -168,3 +179,4 @@ rule run_all:
 rule all:
     input:
         "temp_files/final_metadata.xml",
+        "logs/metadata_validation.json",

--- a/snakefile
+++ b/snakefile
@@ -157,6 +157,7 @@ rule validate_metadata_geonetwork:
         config="config.yaml",
         session="temp_files/geonetwork_session.txt",
         record_id="temp_files/metadata_uploaded.txt",
+        upload_response="temp_files/upload_response.json",
         metadata=rules.update_metadata.output
     output:
         "logs/metadata_validation.json"


### PR DESCRIPTION
### Motivation
- Añadir un paso automático que valide los metadatos subidos/actualizados en Geonetwork usando su API para detectar errores de validación inmediatamente después de la actualización final.
- Integrar la validación en el flujo principal para que el pipeline pueda fallar y reportar problemas antes de considerar el run como completo.

### Description
- Se añade el script `scripts/validation/validate_metadata_geonetwork.py` que toma `config.yaml`, el fichero de sesión (`temp_files/geonetwork_session.txt`) y el `record_id` (`temp_files/metadata_uploaded.txt`), llama a `POST {geonetwork_url}/srv/api/records/{record_id}/validate` usando el token XSRF y cookies guardadas, y escribe la respuesta JSON en `logs/metadata_validation.json` (sale con código de error si la validación falla). 
- Se actualiza el `snakefile` para incluir la nueva regla `validate_metadata_geonetwork` y se enlaza a la regla `run_all` y al objetivo `all` para que la validación forme parte del pipeline completo.
- El script extrae `services.geonetwork.url` desde `config.yaml`, y valida la presencia del token XSRF y del `record_id`, fallando con mensajes claros si falta información.

### Testing
- No se ejecutaron pruebas automatizadas en este cambio (ninguna prueba solicitada ni lanzada durante el cambio).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984a80032e08330a84bf2598f29dcf6)