### PR TITLE
fix: nombres de capa GeoServer, clave S3 y URL del plugin FAIR-EVA

### DIFF
--- a/scripts/final_update/update_metadata.py
+++ b/scripts/final_update/update_metadata.py
@@ -2,6 +2,7 @@
 #!/usr/bin/env python3
 import xml.etree.ElementTree as ET
 import json
+import re
 import sys
 import requests
 import yaml
@@ -13,6 +14,16 @@ namespaces = {
     'gmi': "http://www.isotc211.org/2005/gmi",
     'gml': 'http://www.opengis.net/gml/3.2'
 }
+
+
+def collapse_duplicate_path_segments(url):
+    """Colapsa segmentos de ruta repetidos consecutivos en una URL, p.ej.
+    '.../geonetwork/geonetwork/srv/...' -> '.../geonetwork/srv/...'.
+    GeoNetwork devuelve la URL del attachment con el context path duplicado
+    cuando su base URL está mal configurada, y eso rompe la miniatura."""
+    if not url:
+        return url
+    return re.sub(r'/([^/?#]+)/\1(?=[/?#]|$)', r'/\1', url)
 
 
 def insert_before_first(md_data_id, new_elem, ordered_localnames):
@@ -129,8 +140,10 @@ def update_metadata(xml_file, record_id, combined_response, output_file, wms_url
     mdBrowseGraphic = ET.SubElement(graphicOverview, f"{{{ns_gmd}}}MD_BrowseGraphic")
     fileName = ET.SubElement(mdBrowseGraphic, f"{{{ns_gmd}}}fileName")
     charString = ET.SubElement(fileName, f"{{{ns_gco}}}CharacterString")
-    # Asigna la URL proveniente de png_response
-    charString.text = combined_response.get('png_response', {}).get('url', '')
+    # Asigna la URL proveniente de png_response, saneando un posible context
+    # path duplicado (".../geonetwork/geonetwork/...") que rompe la miniatura.
+    png_url = combined_response.get('png_response', {}).get('url', '')
+    charString.text = collapse_duplicate_path_segments(png_url)
 
     # Intentar insertar la miniatura en el MD_DataIdentification
     ci_citation = root.find(".//gmd:identificationInfo/gmd:MD_DataIdentification", namespaces)

--- a/scripts/generate_xml/publish_geoserver.py
+++ b/scripts/generate_xml/publish_geoserver.py
@@ -6,6 +6,7 @@ import json
 import rasterio
 from rasterio.warp import transform_bounds
 import unicodedata
+import re
 
 def eliminar_acentos(texto):
     # Descompone los caracteres (la 'é' se convierte en 'e' + '´')
@@ -14,6 +15,12 @@ def eliminar_acentos(texto):
     solo_ascii = "".join([c for c in forma_nfkd if not unicodedata.combining(c)])
     return solo_ascii
 
+def sanitizar_nombre(texto):
+    # Nombre apto para GeoServer: sin acentos, espacios ni caracteres
+    # especiales (solo [A-Za-z0-9_]).
+    base = re.sub(r"[^A-Za-z0-9]+", "_", eliminar_acentos(texto)).strip("_")
+    return base or "coverage"
+
 def create_coverage_store(yaml_file, output_file):
     # Parámetros de conexión y configuración
     with open(yaml_file, 'r', encoding='utf-8') as f:
@@ -21,7 +28,11 @@ def create_coverage_store(yaml_file, output_file):
 
     geoserver_url = config.get("services")['geoserver']['url']
     workspace = config.get("services")['geoserver']['workspace']
-    coveragestore = eliminar_acentos(config.get("metadata").get("title"))[0:10]
+    # Nombre del coveragestore derivado del identificador de la escena: único
+    # y sin caracteres problemáticos. Antes se usaba title[0:10], que truncaba
+    # el título y dejaba nombres con espacios como "Mascara de".
+    metadata = config.get("metadata") or {}
+    coveragestore = sanitizar_nombre(metadata.get("identifier") or metadata.get("title") or "coverage")
     style = config.get("services")['geoserver']["style"]
     username = config.get("services")['geoserver']['username']
     password = config.get("services")['geoserver']['password']
@@ -294,7 +305,7 @@ def create_coverage_store(yaml_file, output_file):
 
 
     with open(str(output_file), 'w', encoding='utf-8') as f:
-        ogc_url = f"https://goyas.csic.es/geoserver/{workspace}/ows?SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS={coveragestore}1&STYLES=&CRS=EPSG%3A3857&WIDTH=2040&HEIGHT=892&BBOX={bounds.left}%2C{bounds.bottom}%2C{bounds.right}%2C{bounds.top}&width=768&height=448&srs=EPSG%3A4326"
+        ogc_url = f"https://goyas.csic.es/geoserver/{workspace}/ows?SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS={workspace}%3A{coveragestore}&STYLES=&CRS=EPSG%3A3857&WIDTH=2040&HEIGHT=892&BBOX={bounds.left}%2C{bounds.bottom}%2C{bounds.right}%2C{bounds.top}&width=768&height=448&srs=EPSG%3A4326"
         f.write(ogc_url)
 
 if __name__ == "__main__":

--- a/scripts/upload_data/upload_data.py
+++ b/scripts/upload_data/upload_data.py
@@ -96,30 +96,34 @@ def upload_data(session_file, record_id_file, config, png_file_path, output_file
             sys.stdout.flush()
 
     # === SUBIDA A S3 ===
-    ts_dt = datetime.now(timezone.utc) 
+    ts_dt = datetime.now(timezone.utc)
     ts = ts_dt.isoformat()
+    # Clave del objeto en S3: timestamp + nombre de fichero (basename). Antes se
+    # concatenaba la ruta local completa, generando claves como
+    # "<ts>_/home/user/.../flood.tif".
+    object_key = ts + "_" + os.path.basename(local_file)
     transfer = S3Transfer(client=s3, config=tfr_cfg)
     transfer.upload_file(
         local_file,
         bucket_name,
-        ts + "_" + local_file,
+        object_key,
         callback=ProgressPercentage(local_file),
         extra_args={'ACL': 'public-read'}
     )
     print("\n✅ Subida de TIFF completada.")
-    
+
 
     # Generar URL firmada (1 hora)
     signed_url = s3.generate_presigned_url(
         'get_object',
-        Params={'Bucket': bucket_name, 'Key': ts + "_" + local_file},
+        Params={'Bucket': bucket_name, 'Key': object_key},
         ExpiresIn=3600
     )
     print(f"🔐 URL firmada (1 h): {signed_url}")
 
     # Guardar las respuestas combinadas en un archivo JSON
     combined_response = {
-        "tif_response": {"url": f"https://portal.cloud.ifca.es/api/swift/containers/{bucket_name}/object/{ts}_{local_file}", "filename": ts + "_" + local_file},
+        "tif_response": {"url": f"https://portal.cloud.ifca.es/api/swift/containers/{bucket_name}/object/{object_key}", "filename": object_key},
         "png_response": png_response.json()
     }
     with open(output_file, 'w', encoding='utf-8') as f:

--- a/scripts/validation/validate_fair_eva.py
+++ b/scripts/validation/validate_fair_eva.py
@@ -173,7 +173,7 @@ def run_fair_eva_validation(config_file, upload_response_file, record_id_file, m
         raise RuntimeError(
             "No se pudo importar el plugin FAIR-EVA de GOYAS. "
             "Instala la dependencia en el entorno del workflow, por ejemplo: "
-            "'pip install git+https://github.com/IFCA-Advanced-Computing/fair_eva_plugin_goyas'"
+            "'pip install git+https://github.com/ferag/fair-eva-plugin-goyas'"
         ) from exc
 
     config_data = plugin_module.Plugin.load_config(plugin_path)


### PR DESCRIPTION
Tres correcciones encontradas al ejecutar el workflow end-to-end con una escena real (máscara de inundación de Doñana, pipeline ProtocoloV3).

## 1. `publish_geoserver.py` — nombre del coveragestore/capa
El nombre del coveragestore se obtenía con `eliminar_acentos(title)[0:10]`, que **trunca el título a 10 caracteres** y deja nombres con espacios. Con el título "Máscara de inundación Doñana — ..." el resultado era el coveragestore `Mascara de`.

Ahora se deriva del identificador de la escena (`metadata.identifier`) y se sanea a `[A-Za-z0-9_]` con un helper `sanitizar_nombre()`. Resultado: nombres únicos y sin caracteres problemáticos (p.ej. `20260515s2msi202_34`).

También se corrige el parámetro `LAYERS` de la URL WMS generada, que añadía un `1` espurio al nombre de capa (`LAYERS={coveragestore}1`) → ahora `LAYERS={workspace}:{coveragestore}`.

## 2. `upload_data.py` — clave del objeto en S3
La clave del objeto subido a S3 concatenaba la **ruta local absoluta completa**:
`2026-05-21T...+00:00_/home/user/.../20260515s2msi202_34_flood.tif`

Ahora usa solo el basename del fichero: `<ts>_20260515s2msi202_34_flood.tif`.

## 3. `validate_fair_eva.py` — URL del plugin en el mensaje de error
El mensaje de error al fallar el import del plugin apuntaba a un repo que no existe (`IFCA-Advanced-Computing/fair_eva_plugin_goyas`, 404). Se corrige a la URL pública real: `ferag/fair-eva-plugin-goyas`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)